### PR TITLE
Fix error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ help:
 	@echo "make console"
 
 console:
-	irb -r rubygems -I lib -r zoom.rb
+	irb -r rubygems -I lib -r zoom_rb.rb

--- a/lib/zoom/error.rb
+++ b/lib/zoom/error.rb
@@ -3,12 +3,15 @@
 module Zoom
   class Error < StandardError
     attr_reader :error_hash
+    attr_reader :code
 
-    def initialize(msg, error_hash={})
+    def initialize(msg, error_hash={}, code: nil)
       @error_hash = error_hash
+      @code = code
       super(msg)
     end
   end
+
   class GatewayTimeout < StandardError; end
   class NotImplemented < StandardError; end
   class ParameterMissing < StandardError; end


### PR DESCRIPTION
Previous error handling logic was not taking into account all error scenarios.

New logic is as per the Zoom docs https://developers.zoom.us/docs/api/rest/error-definitions/

SL-4534